### PR TITLE
Add MATLAB closed-loop joint IO identification scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,19 @@
 # Codex
+
+MATLAB scripts demonstrating closed-loop identification using a joint input-output approach.
+
+## Files
+- `main_closedloop_jointIO.m` – orchestrates data generation, identification and validation.
+- `simulate_cl.m` – simulates closed-loop data given a plant and controller.
+- `identify_Tyr_Tur.m` – estimates transfer functions from reference to output and input.
+- `post_analysis.m` – compares estimated and true models and performs residual analysis.
+
+## Requirements
+MATLAB with the Control System and System Identification Toolboxes (or equivalent Octave packages).
+
+## Usage
+Run the main script from MATLAB:
+```matlab
+main_closedloop_jointIO
+```
+The script saves simulated datasets (`cl_data.mat`), identified models (`identified_models.mat`) and produces diagnostic plots.

--- a/identify_Tyr_Tur.m
+++ b/identify_Tyr_Tur.m
@@ -1,0 +1,34 @@
+function [G_hat, Tyr_hat, Tur_hat] = identify_Tyr_Tur(data, nb, nf)
+%IDENTIFY_TYR_TUR  Estimate Tyr and Tur from closed-loop data.
+%   [G,Tyr,Tur] = IDENTIFY_TYR_TUR(DATA, NB, NF) estimates the closed-loop
+%   transfer functions from reference to output (Tyr) and from reference to
+%   control input (Tur) using TFEST.  DATA is a structure produced by
+%   SIMULATE_CL containing fields r, u, y and Ts.  NB and NF specify the
+%   numerator and denominator orders for the TF models.
+%
+%   The plant model is returned as G = Tyr/Tur.
+%
+%   Example:
+%       est = struct('r',r_est,'u',u_est,'y',y_est,'Ts',0.01);
+%       [G,Tyr,Tur] = identify_Tyr_Tur(est,2,2);
+%
+%   Requires the System Identification Toolbox.
+%
+%   See also: SIMULATE_CL, POST_ANALYSIS
+
+if nargin < 3
+    error('Model orders NB and NF must be provided.');
+end
+
+% build iddata objects
+data_ry = iddata(data.y, data.r, data.Ts);
+data_ru = iddata(data.u, data.r, data.Ts);
+
+% estimate transfer functions
+Tyr_hat = tfest(data_ry, nb, nf);
+Tur_hat = tfest(data_ru, nb, nf);
+
+% plant estimate
+g_try = minreal(Tyr_hat/Tur_hat);
+G_hat = idtf(g_try);
+end

--- a/main_closedloop_jointIO.m
+++ b/main_closedloop_jointIO.m
@@ -1,0 +1,40 @@
+%% MAIN_CLOSEDLOOP_JOINTIO
+% Demonstration script for closed-loop identification using joint input
+% output approach.  The script generates data, performs identification and
+% validates the result.
+%
+% Requires Control System and System Identification Toolboxes.
+
+clear; close all; clc;
+
+%% User settings
+Ts  = 0.01;       % Sampling period [s]
+N   = 5000;       % Number of samples
+SNR = 20;         % Signal-to-noise ratio of disturbance [dB]
+nb  = 2; nf = 2;  % Transfer function model orders
+
+% True plant and controller
+G0 = tf([0.5],[1 -1.5 0.7],Ts);
+C0 = pid(0.5,0.1,0,Ts);
+
+%% Closed-loop simulation
+data = simulate_cl(G0, C0, Ts, N, SNR);
+
+% Split into estimation and validation sets
+Ne = floor(0.7*N);
+est = struct('r',data.r(1:Ne), 'u',data.u(1:Ne), 'y',data.y(1:Ne), 'Ts',Ts);
+val = struct('r',data.r(Ne+1:end), 'u',data.u(Ne+1:end), 'y',data.y(Ne+1:end), 'Ts',Ts);
+
+% Save data as iddata objects for reproducibility
+id_est = iddata(est.y, [est.r est.u], Ts, 'InputName',{'r','u'}, 'OutputName',{'y'});
+id_val = iddata(val.y, [val.r val.u], Ts, 'InputName',{'r','u'}, 'OutputName',{'y'});
+save('cl_data.mat','id_est','id_val');
+
+%% Identification
+[G_hat, Tyr_hat, Tur_hat] = identify_Tyr_Tur(est, nb, nf);
+
+%% Post analysis
+metrics = post_analysis(G_hat, G0, C0, val);
+
+%% Save models
+save('identified_models.mat','G_hat','Tyr_hat','Tur_hat','metrics');

--- a/post_analysis.m
+++ b/post_analysis.m
@@ -1,0 +1,31 @@
+function metrics = post_analysis(G_hat, G0, C0, data_val)
+%POST_ANALYSIS  Validate identified plant model against validation data.
+%   METRICS = POST_ANALYSIS(G, G0, C0, DATA) compares the estimated plant
+%   G with the true plant G0 using validation dataset DATA (structure with
+%   fields r, u, y, Ts).  The controller C0 is used to recreate the closed
+%   loop.  Bode and step responses are plotted, together with residual
+%   analysis.  The function returns a structure METRICS containing the fit
+%   percentage for the output.
+%
+%   Requires Control System and System Identification Toolboxes.
+%
+%   See also: SIMULATE_CL, IDENTIFY_TYR_TUR
+
+% iddata for validation
+val_ry = iddata(data_val.y, data_val.r, data_val.Ts);
+
+% closed-loop transfer using identified plant
+Tyr_hat = feedback(G_hat*C0,1);
+[~, fit, ~] = compare(val_ry, Tyr_hat);
+
+% plots
+figure; bodeplot(G0, G_hat); grid on;
+legend('True G_0','Estimated G'); title('Bode magnitude and phase');
+
+figure; step(feedback(G0*C0,1), feedback(G_hat*C0,1));
+legend('True','Estimated'); title('Closed-loop step response');
+
+figure; resid(val_ry, Tyr_hat); title('Residual analysis');
+
+metrics.fit = fit;
+end

--- a/simulate_cl.m
+++ b/simulate_cl.m
@@ -1,0 +1,58 @@
+function data = simulate_cl(G0, C0, Ts, N, SNR)
+%SIMULATE_CL  Generate closed-loop data for joint IO identification.
+%   DATA = SIMULATE_CL(G0, C0, TS, N, SNR) returns simulated reference,
+%   control input and output signals for the plant G0 under the controller
+%   C0.  TS is the sampling period, N is the number of samples and SNR is
+%   the desired signal-to-noise ratio (in dB) for an additive output
+%   disturbance.
+%
+%   The reference signal is a PRBS generated with IDINPUT and the
+%   disturbance is white noise scaled to achieve the specified SNR.  The
+%   closed-loop signals are computed using linear dynamic models and LSIM.
+%
+%   The output DATA is a structure with fields:
+%       r  - reference signal
+%       u  - control input
+%       y  - measured output
+%       Ts - sampling period
+%
+%   Example:
+%       G0 = tf([0.5],[1 -1.5 0.7],0.01);
+%       C0 = pid(0.5,0.1,0,0.01);
+%       data = simulate_cl(G0,C0,0.01,5000,20);
+%
+%   Requires Control System and System Identification Toolboxes.
+%
+%   See also: IDENTIFY_TYR_TUR, POST_ANALYSIS
+
+% time vector
+T = (0:N-1)'*Ts;
+
+% reference: pseudo random binary sequence
+r = idinput(N,'prbs',[0 1/Ts],[ -1 1 ]);
+
+% disturbance with specified SNR at the plant output
+raw_v = randn(N,1);
+% simulate nominal output to estimate signal power
+Tyr_nom = feedback(G0*C0,1);
+y_nom = lsim(Tyr_nom,r,T);
+P_signal = var(y_nom);
+P_noise = P_signal/10^(SNR/10);
+v = raw_v*sqrt(P_noise/var(raw_v));
+
+% closed-loop transfer functions
+Tyr = feedback(G0*C0,1);        % r -> y
+Tyv = feedback(1,G0*C0);        % v -> y
+Tur = feedback(C0,G0);          % r -> u
+Tuv = -C0*Tyv;                  % v -> u
+
+% simulate
+y = lsim(Tyr,r,T) + lsim(Tyv,v,T);
+u = lsim(Tur,r,T) + lsim(Tuv,v,T);
+
+% package data
+data.r = r;
+data.u = u;
+data.y = y;
+data.Ts = Ts;
+end


### PR DESCRIPTION
## Summary
- Implement MATLAB script `simulate_cl` to generate closed-loop data with PRBS reference and noise for a given plant and controller
- Add `identify_Tyr_Tur` and `post_analysis` functions to estimate closed-loop transfer functions, compute plant model and validate via Bode/step/residual plots
- Provide `main_closedloop_jointIO` orchestrating simulation, identification, validation and saving of datasets and models, plus updated README instructions

## Testing
- `matlab -batch "disp('version')"` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c79f483df0832b9d433d910c024380