### PR TITLE
Fix PRBS generation band

### DIFF
--- a/simulate_cl.m
+++ b/simulate_cl.m
@@ -29,20 +29,23 @@ function data = simulate_cl(G0, C0, Ts, N, SNR)
 T = (0:N-1)'*Ts;
 
 % reference: pseudo random binary sequence
-r = idinput(N, 'prbs', [], [-1 1]);  % 帯域指定を外す
+% Generate PRBS within the default 0 to 0.5 Nyquist band to avoid
+% undefined signal generation at high frequencies.
+r = idinput(N, 'prbs', [0 0.5], [-1 1]);
 
 % disturbance with specified SNR at the plant output
 raw_v = randn(N,1);
 % simulate nominal output to estimate signal power
-Tyr_nom = feedback(G0*C0,1);
+I = tf(1,1,Ts);
+Tyr_nom = feedback(G0*C0,I);
 y_nom = lsim(Tyr_nom,r,T);
 P_signal = var(y_nom);
 P_noise = P_signal/10^(SNR/10);
 v = raw_v*sqrt(P_noise/var(raw_v));
 
 % closed-loop transfer functions
-Tyr = feedback(G0*C0,1);        % r -> y
-Tyv = feedback(1,G0*C0);        % v -> y
+Tyr = feedback(G0*C0,I);        % r -> y
+Tyv = feedback(I,G0*C0);        % v -> y
 Tur = feedback(C0,G0);          % r -> u
 Tuv = -C0*Tyv;                  % v -> u
 


### PR DESCRIPTION
## Summary
- translate inline PRBS reference comment to English in `simulate_cl.m`
- constrain PRBS reference generation to the default Nyquist band to avoid undefined signals
- align feedback loops with a discrete-time identity to enforce matching sample times

## Testing
- `octave --version` *(fails: command not found)*
- `apt-get update` *(fails: repository InRelease not signed)*
- `apt-get install -y octave` *(fails: unable to locate package)*

------
https://chatgpt.com/codex/tasks/task_e_68c7a7533468832bbb83ed4524ff1523