### PR TITLE
Add SwiftUI Tetris game for iOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,9 +7,12 @@ MATLAB scripts demonstrating closed-loop identification using a joint input-outp
 - `simulate_cl.m` – simulates closed-loop data given a plant and controller.
 - `identify_Tyr_Tur.m` – estimates transfer functions from reference to output and input.
 - `post_analysis.m` – compares estimated and true models and performs residual analysis.
+- `TetrisGame/` – SwiftUI implementation of a Tetris game for iOS.
 
 ## Requirements
 MATLAB with the Control System and System Identification Toolboxes (or equivalent Octave packages).
+
+For the iOS project, Xcode 14 or later with the iOS SDK.
 
 ## Usage
 Run the main script from MATLAB:
@@ -17,3 +20,8 @@ Run the main script from MATLAB:
 main_closedloop_jointIO
 ```
 The script saves simulated datasets (`cl_data.mat`), identified models (`identified_models.mat`) and produces diagnostic plots.
+
+### iOS Tetris Game
+1. Open the `TetrisGame` folder in Xcode (`File > Open...`).
+2. Build and run the `TetrisGameApp` target on the iOS Simulator or a physical device.
+3. Use the on-screen controls to move, rotate, soft drop, and hard drop the falling tetrominoes.

--- a/TetrisGame/ContentView.swift
+++ b/TetrisGame/ContentView.swift
@@ -1,0 +1,166 @@
+import SwiftUI
+
+struct ContentView: View {
+    @StateObject private var gameState = GameState()
+
+    private let boardSpacing: CGFloat = 2
+
+    var body: some View {
+        GeometryReader { geometry in
+            let cellSize = min(
+                (geometry.size.width - 32) / CGFloat(gameState.columns + 6),
+                (geometry.size.height - 32) / CGFloat(gameState.rows + 4)
+            )
+
+            VStack(spacing: 16) {
+                header
+                HStack(alignment: .top, spacing: 16) {
+                    boardView(cellSize: cellSize)
+                    sidePanel(cellSize: cellSize)
+                }
+                controlPanel
+            }
+            .padding(16)
+            .frame(maxWidth: .infinity, maxHeight: .infinity)
+            .background(Color(.systemBackground))
+        }
+        .ignoresSafeArea(.keyboard, edges: .bottom)
+    }
+
+    private var header: some View {
+        HStack {
+            VStack(alignment: .leading, spacing: 8) {
+                Text("Score \(gameState.score)")
+                    .font(.title2)
+                    .fontWeight(.bold)
+                Text("Level \(gameState.level)")
+                    .font(.headline)
+                Text("Lines \(gameState.linesCleared)")
+                    .font(.headline)
+            }
+            Spacer()
+            VStack(spacing: 8) {
+                Button(gameState.isPaused ? "Resume" : "Pause") {
+                    gameState.togglePause()
+                }
+                .buttonStyle(.borderedProminent)
+                Button("Restart") {
+                    gameState.resetGame()
+                }
+                .buttonStyle(.bordered)
+            }
+        }
+    }
+
+    private func boardView(cellSize: CGFloat) -> some View {
+        ZStack {
+            RoundedRectangle(cornerRadius: 12)
+                .fill(Color(.secondarySystemBackground))
+            VStack(spacing: boardSpacing) {
+                ForEach(0..<gameState.rows, id: \.self) { row in
+                    HStack(spacing: boardSpacing) {
+                        ForEach(0..<gameState.columns, id: \.self) { column in
+                            cellView(for: row, column: column)
+                                .frame(width: cellSize, height: cellSize)
+                        }
+                    }
+                }
+            }
+            .padding(8)
+
+            if gameState.isGameOver {
+                VStack(spacing: 12) {
+                    Text("Game Over")
+                        .font(.largeTitle)
+                        .fontWeight(.heavy)
+                    Button("Play Again") {
+                        gameState.resetGame()
+                    }
+                    .buttonStyle(.borderedProminent)
+                }
+                .padding()
+                .background(.ultraThinMaterial, in: RoundedRectangle(cornerRadius: 12))
+            }
+        }
+    }
+
+    private func sidePanel(cellSize: CGFloat) -> some View {
+        VStack(alignment: .leading, spacing: 16) {
+            VStack(alignment: .leading, spacing: 8) {
+                Text("Next")
+                    .font(.headline)
+                nextPiecePreview(cellSize: cellSize * 0.75)
+            }
+            Spacer()
+        }
+        .frame(width: cellSize * 5)
+    }
+
+    private func nextPiecePreview(cellSize: CGFloat) -> some View {
+        let previewGrid = Array(repeating: GridItem(.fixed(cellSize), spacing: 4), count: 4)
+        return LazyVGrid(columns: previewGrid, spacing: 4) {
+            ForEach(0..<4, id: \.self) { row in
+                ForEach(0..<4, id: \.self) { column in
+                    RoundedRectangle(cornerRadius: 4)
+                        .fill(gameState.nextPieceColor(row: row, column: column))
+                        .frame(width: cellSize, height: cellSize)
+                }
+            }
+        }
+        .padding(8)
+        .background(RoundedRectangle(cornerRadius: 12).fill(Color(.secondarySystemBackground)))
+    }
+
+    private var controlPanel: some View {
+        VStack(spacing: 12) {
+            HStack(spacing: 16) {
+                Button {
+                    gameState.moveLeft()
+                } label: {
+                    Image(systemName: "arrow.left")
+                        .frame(width: 44, height: 44)
+                }
+                .buttonStyle(.bordered)
+
+                Button {
+                    gameState.softDrop()
+                } label: {
+                    Image(systemName: "arrow.down")
+                        .frame(width: 44, height: 44)
+                }
+                .buttonStyle(.borderedProminent)
+
+                Button {
+                    gameState.moveRight()
+                } label: {
+                    Image(systemName: "arrow.right")
+                        .frame(width: 44, height: 44)
+                }
+                .buttonStyle(.bordered)
+            }
+
+            HStack(spacing: 16) {
+                Button("Rotate") {
+                    gameState.rotate()
+                }
+                .buttonStyle(.bordered)
+
+                Button("Hard Drop") {
+                    gameState.hardDrop()
+                }
+                .buttonStyle(.borderedProminent)
+            }
+        }
+    }
+
+    private func cellView(for row: Int, column: Int) -> some View {
+        RoundedRectangle(cornerRadius: 4)
+            .fill(gameState.colorForCell(row: row, column: column))
+    }
+}
+
+struct ContentView_Previews: PreviewProvider {
+    static var previews: some View {
+        ContentView()
+    }
+}

--- a/TetrisGame/Models/GameState.swift
+++ b/TetrisGame/Models/GameState.swift
@@ -1,0 +1,212 @@
+import SwiftUI
+
+final class GameState: ObservableObject {
+    let rows = 20
+    let columns = 10
+
+    @Published private(set) var board: [[TetrominoType?]]
+    @Published var currentTetromino: Tetromino
+    @Published var nextTetromino: TetrominoType
+    @Published var score: Int = 0
+    @Published var level: Int = 1
+    @Published var linesCleared: Int = 0
+    @Published var isGameOver: Bool = false
+    @Published var isPaused: Bool = false
+
+    private var timer: Timer?
+
+    init() {
+        let emptyRow = Array<TetrominoType?>(repeating: nil, count: columns)
+        board = Array(repeating: emptyRow, count: rows)
+        currentTetromino = Tetromino(type: .i, rotationIndex: 0, position: Point(row: 0, column: columns / 2 - 2))
+        nextTetromino = TetrominoType.random()
+        resetGame()
+    }
+
+    deinit {
+        timer?.invalidate()
+    }
+
+    func resetGame() {
+        timer?.invalidate()
+        isGameOver = false
+        isPaused = false
+        score = 0
+        level = 1
+        linesCleared = 0
+
+        let emptyRow = Array<TetrominoType?>(repeating: nil, count: columns)
+        board = Array(repeating: emptyRow, count: rows)
+        nextTetromino = TetrominoType.random()
+        spawnTetromino()
+        scheduleTimer()
+    }
+
+    func togglePause() {
+        guard !isGameOver else { return }
+        isPaused.toggle()
+        if isPaused {
+            timer?.invalidate()
+        } else {
+            scheduleTimer()
+        }
+    }
+
+    func moveLeft() {
+        guard !isPaused, !isGameOver else { return }
+        let newPosition = Point(row: currentTetromino.position.row, column: currentTetromino.position.column - 1)
+        if isValid(tetromino: currentTetromino, position: newPosition) {
+            currentTetromino.position = newPosition
+        }
+    }
+
+    func moveRight() {
+        guard !isPaused, !isGameOver else { return }
+        let newPosition = Point(row: currentTetromino.position.row, column: currentTetromino.position.column + 1)
+        if isValid(tetromino: currentTetromino, position: newPosition) {
+            currentTetromino.position = newPosition
+        }
+    }
+
+    func softDrop() {
+        guard !isPaused, !isGameOver else { return }
+        if !moveDown() {
+            lockCurrentTetromino()
+        }
+    }
+
+    func hardDrop() {
+        guard !isPaused, !isGameOver else { return }
+        while moveDown() { }
+        lockCurrentTetromino()
+    }
+
+    func rotate() {
+        guard !isPaused, !isGameOver else { return }
+        let rotated = currentTetromino.rotated()
+        if isValid(tetromino: rotated) {
+            currentTetromino = rotated
+        } else {
+            // Wall kick attempt: try shifting left or right by one cell.
+            let leftShift = Point(row: rotated.position.row, column: rotated.position.column - 1)
+            if isValid(tetromino: rotated, position: leftShift) {
+                currentTetromino = Tetromino(type: rotated.type, rotationIndex: rotated.rotationIndex, position: leftShift)
+                return
+            }
+            let rightShift = Point(row: rotated.position.row, column: rotated.position.column + 1)
+            if isValid(tetromino: rotated, position: rightShift) {
+                currentTetromino = Tetromino(type: rotated.type, rotationIndex: rotated.rotationIndex, position: rightShift)
+            }
+        }
+    }
+
+    func colorForCell(row: Int, column: Int) -> Color {
+        if let fixedType = board[row][column] {
+            return fixedType.color
+        }
+
+        if currentTetromino.blocks().contains(where: { $0.row == row && $0.column == column }) {
+            return currentTetromino.type.color.opacity(0.9)
+        }
+
+        return Color(.tertiarySystemFill)
+    }
+
+    func nextPieceColor(row: Int, column: Int) -> Color {
+        let preview = Tetromino(type: nextTetromino, rotationIndex: 0, position: Point(row: 0, column: 0))
+        if preview.blocks().contains(where: { $0.row == row && $0.column == column }) {
+            return nextTetromino.color
+        }
+        return Color(.tertiarySystemFill)
+    }
+
+    private func moveDown() -> Bool {
+        let newPosition = Point(row: currentTetromino.position.row + 1, column: currentTetromino.position.column)
+        if isValid(tetromino: currentTetromino, position: newPosition) {
+            currentTetromino.position = newPosition
+            return true
+        }
+        return false
+    }
+
+    private func spawnTetromino() {
+        let spawnColumn = columns / 2 - 2
+        currentTetromino = Tetromino(type: nextTetromino, rotationIndex: 0, position: Point(row: -1, column: spawnColumn))
+        nextTetromino = TetrominoType.random()
+        if !isValid(tetromino: currentTetromino) {
+            isGameOver = true
+            timer?.invalidate()
+        }
+    }
+
+    private func lockCurrentTetromino() {
+        for block in currentTetromino.blocks() {
+            guard block.row >= 0 else {
+                isGameOver = true
+                timer?.invalidate()
+                return
+            }
+            board[block.row][block.column] = currentTetromino.type
+        }
+        clearCompletedLines()
+        spawnTetromino()
+    }
+
+    private func clearCompletedLines() {
+        var newBoard: [[TetrominoType?]] = []
+        var clearedLines = 0
+
+        for row in board {
+            if row.allSatisfy({ $0 != nil }) {
+                clearedLines += 1
+            } else {
+                newBoard.append(row)
+            }
+        }
+
+        while newBoard.count < rows {
+            newBoard.insert(Array(repeating: nil, count: columns), at: 0)
+        }
+
+        board = newBoard
+
+        guard clearedLines > 0 else { return }
+
+        linesCleared += clearedLines
+        level = 1 + linesCleared / 10
+
+        let lineScores = [0, 40, 100, 300, 1200]
+        let gained = lineScores[min(clearedLines, 4)] * level
+        score += gained
+
+        scheduleTimer()
+    }
+
+    private func isValid(tetromino: Tetromino, position: Point? = nil) -> Bool {
+        let testPosition = position ?? tetromino.position
+        for block in tetromino.blocks(position: testPosition) {
+            if block.column < 0 || block.column >= columns {
+                return false
+            }
+            if block.row >= rows {
+                return false
+            }
+            if block.row >= 0 && board[block.row][block.column] != nil {
+                return false
+            }
+        }
+        return true
+    }
+
+    private func scheduleTimer() {
+        timer?.invalidate()
+        guard !isPaused, !isGameOver else { return }
+        let interval = max(0.1, 0.8 - Double(level - 1) * 0.05)
+        timer = Timer.scheduledTimer(withTimeInterval: interval, repeats: true) { [weak self] _ in
+            guard let self else { return }
+            if !self.moveDown() {
+                self.lockCurrentTetromino()
+            }
+        }
+    }
+}

--- a/TetrisGame/Models/Tetromino.swift
+++ b/TetrisGame/Models/Tetromino.swift
@@ -1,0 +1,228 @@
+import SwiftUI
+
+struct Point: Hashable {
+    var row: Int
+    var column: Int
+}
+
+enum TetrominoType: CaseIterable {
+    case i, o, t, s, z, j, l
+
+    var color: Color {
+        switch self {
+        case .i: return Color.cyan
+        case .o: return Color.yellow
+        case .t: return Color.purple
+        case .s: return Color.green
+        case .z: return Color.red
+        case .j: return Color.blue
+        case .l: return Color.orange
+        }
+    }
+
+    var rotations: [[[Int]]] {
+        switch self {
+        case .i:
+            return [
+                [
+                    [0, 0, 0, 0],
+                    [1, 1, 1, 1],
+                    [0, 0, 0, 0],
+                    [0, 0, 0, 0]
+                ],
+                [
+                    [0, 1, 0, 0],
+                    [0, 1, 0, 0],
+                    [0, 1, 0, 0],
+                    [0, 1, 0, 0]
+                ],
+                [
+                    [0, 0, 0, 0],
+                    [1, 1, 1, 1],
+                    [0, 0, 0, 0],
+                    [0, 0, 0, 0]
+                ],
+                [
+                    [0, 1, 0, 0],
+                    [0, 1, 0, 0],
+                    [0, 1, 0, 0],
+                    [0, 1, 0, 0]
+                ]
+            ]
+        case .o:
+            let shape = [
+                [0, 1, 1, 0],
+                [0, 1, 1, 0],
+                [0, 0, 0, 0],
+                [0, 0, 0, 0]
+            ]
+            return [shape, shape, shape, shape]
+        case .t:
+            return [
+                [
+                    [0, 1, 0, 0],
+                    [1, 1, 1, 0],
+                    [0, 0, 0, 0],
+                    [0, 0, 0, 0]
+                ],
+                [
+                    [0, 1, 0, 0],
+                    [0, 1, 1, 0],
+                    [0, 1, 0, 0],
+                    [0, 0, 0, 0]
+                ],
+                [
+                    [0, 0, 0, 0],
+                    [1, 1, 1, 0],
+                    [0, 1, 0, 0],
+                    [0, 0, 0, 0]
+                ],
+                [
+                    [0, 1, 0, 0],
+                    [1, 1, 0, 0],
+                    [0, 1, 0, 0],
+                    [0, 0, 0, 0]
+                ]
+            ]
+        case .s:
+            return [
+                [
+                    [0, 1, 1, 0],
+                    [1, 1, 0, 0],
+                    [0, 0, 0, 0],
+                    [0, 0, 0, 0]
+                ],
+                [
+                    [0, 1, 0, 0],
+                    [0, 1, 1, 0],
+                    [0, 0, 1, 0],
+                    [0, 0, 0, 0]
+                ],
+                [
+                    [0, 1, 1, 0],
+                    [1, 1, 0, 0],
+                    [0, 0, 0, 0],
+                    [0, 0, 0, 0]
+                ],
+                [
+                    [0, 1, 0, 0],
+                    [0, 1, 1, 0],
+                    [0, 0, 1, 0],
+                    [0, 0, 0, 0]
+                ]
+            ]
+        case .z:
+            return [
+                [
+                    [1, 1, 0, 0],
+                    [0, 1, 1, 0],
+                    [0, 0, 0, 0],
+                    [0, 0, 0, 0]
+                ],
+                [
+                    [0, 0, 1, 0],
+                    [0, 1, 1, 0],
+                    [0, 1, 0, 0],
+                    [0, 0, 0, 0]
+                ],
+                [
+                    [1, 1, 0, 0],
+                    [0, 1, 1, 0],
+                    [0, 0, 0, 0],
+                    [0, 0, 0, 0]
+                ],
+                [
+                    [0, 0, 1, 0],
+                    [0, 1, 1, 0],
+                    [0, 1, 0, 0],
+                    [0, 0, 0, 0]
+                ]
+            ]
+        case .j:
+            return [
+                [
+                    [1, 0, 0, 0],
+                    [1, 1, 1, 0],
+                    [0, 0, 0, 0],
+                    [0, 0, 0, 0]
+                ],
+                [
+                    [0, 1, 1, 0],
+                    [0, 1, 0, 0],
+                    [0, 1, 0, 0],
+                    [0, 0, 0, 0]
+                ],
+                [
+                    [0, 0, 0, 0],
+                    [1, 1, 1, 0],
+                    [0, 0, 1, 0],
+                    [0, 0, 0, 0]
+                ],
+                [
+                    [0, 1, 0, 0],
+                    [0, 1, 0, 0],
+                    [1, 1, 0, 0],
+                    [0, 0, 0, 0]
+                ]
+            ]
+        case .l:
+            return [
+                [
+                    [0, 0, 1, 0],
+                    [1, 1, 1, 0],
+                    [0, 0, 0, 0],
+                    [0, 0, 0, 0]
+                ],
+                [
+                    [0, 1, 0, 0],
+                    [0, 1, 0, 0],
+                    [0, 1, 1, 0],
+                    [0, 0, 0, 0]
+                ],
+                [
+                    [0, 0, 0, 0],
+                    [1, 1, 1, 0],
+                    [1, 0, 0, 0],
+                    [0, 0, 0, 0]
+                ],
+                [
+                    [1, 1, 0, 0],
+                    [0, 1, 0, 0],
+                    [0, 1, 0, 0],
+                    [0, 0, 0, 0]
+                ]
+            ]
+        }
+    }
+
+    static func random() -> TetrominoType {
+        allCases.randomElement() ?? .i
+    }
+}
+
+struct Tetromino {
+    let type: TetrominoType
+    var rotationIndex: Int
+    var position: Point
+
+    func blocks(rotationIndex: Int? = nil, position: Point? = nil) -> [Point] {
+        let index = rotationIndex ?? self.rotationIndex
+        let origin = position ?? self.position
+        let matrix = type.rotations[index]
+        var points: [Point] = []
+
+        for row in 0..<matrix.count {
+            for column in 0..<matrix[row].count where matrix[row][column] == 1 {
+                points.append(Point(row: origin.row + row, column: origin.column + column))
+            }
+        }
+
+        return points
+    }
+
+    func rotated() -> Tetromino {
+        var copy = self
+        copy.rotationIndex = (copy.rotationIndex + 1) % type.rotations.count
+        return copy
+    }
+}

--- a/TetrisGame/TetrisGameApp.swift
+++ b/TetrisGame/TetrisGameApp.swift
@@ -1,0 +1,10 @@
+import SwiftUI
+
+@main
+struct TetrisGameApp: App {
+    var body: some Scene {
+        WindowGroup {
+            ContentView()
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add a SwiftUI-based Tetris game interface with score, level, next-piece preview, and on-screen controls
- implement game state management including tetromino logic, collision checks, line clearing, and scoring
- update the README with instructions for building and playing the new iOS app

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68de7512cccc832ba84fe00e12d485e3